### PR TITLE
porting the phantomjs server code into the middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   },
   "scripts": {
     "test": "mocha"
+  },
+  "dependencies": {
+    "phantomjs": "~1.9.2-2",
+    "phantom": "~0.5.2"
   }
 }


### PR DESCRIPTION
In the case of express middleware, its not necessary to export the dirty work to an external server. Uses some existing prerender server code, and some from my [pull request](https://github.com/collectiveip/prerender/pull/7). This changes the project somewhat significantly, so I'd understand if you'd prefer this be re-published as something else.
