### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
-node_modules
 test
 .travis.yml


### PR DESCRIPTION
Turns out that the node_modules in .npmignore is redundant, according to the docs. Sorry this took two tries to get both right and tidy.

https://npmjs.org/doc/developers.html
