### PR TITLE
Request rendered pages from prerender with gzip encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,23 +147,18 @@ prerender.getPrerenderedPageResponse = function(req, res, callback) {
     options.headers['accept-encoding'] = acceptEncoding;
   }
 
-  var renderRequest = request(options);
+  var renderRequest = request.get(options);
 
   renderRequest.on('response', function (renderResponse) {
-    if (renderResponse.statusCode !== 200) {
-      callback(null);
-    } else {
+    res.set(renderResponse.headers);
 
-      res.set(renderResponse.headers);
+    renderResponse.on('data', function(chunk) {
+      res.write(chunk);
+    });
 
-      renderResponse.on('data', function(chunk) {
-        res.write(chunk);
-      });
-
-      renderResponse.on('end', function(chunk) {
-        callback(renderResponse);
-      });
-    }
+    renderResponse.on('end', function(chunk) {
+      callback(renderResponse);
+    });
   });
 
   renderRequest.on('error', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -1,190 +1,203 @@
 var assert = require('assert')
   , sinon = require('sinon')
   , prerender = require('../index')
+  , request    = require('request')
   , bot = 'Baiduspider+(+http://www.baidu.com/search/spider.htm)'
   , user = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.76 Safari/537.36';
 
+function mockRequest(statusCode, body, headers) {
+  return {
+    on: function (name, f) {
+      if (name === 'response') {
+        f({
+            statusCode: statusCode,
+            headers: headers,
+            on: function (name, f) {
+              if (name === 'data') {
+                f(body);
+              } else if (name === 'end') {
+                f();
+              }
+            }
+          });
+      }
+    }
+  };
+}
+
 describe('Prerender', function(){
 
-  it('should return a prerendered response with the returned status code and headers', function(){
-    var req = { method: 'GET', url: '/', headers: { 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
+  describe('#prerender', function(){
+
+    var res, next;
+
+    beforeEach(function () {
+      res = { send: sinon.stub(), set: sinon.stub(), write: sinon.stub() };
       next = sinon.stub();
-
-    sinon.stub(prerender, 'getPrerenderedPageResponse').callsArgWith(1, {statusCode: 301, body: '<html></html>', headers: { 'Location': 'http://google.com'}});
-
-    prerender(req, res, next);
-
-    prerender.getPrerenderedPageResponse.restore();
-
-    assert.equal(next.callCount, 0);
-    assert.equal(res.send.callCount, 1);
-    assert.deepEqual(res.set.getCall(0).args[0], { 'Location': 'http://google.com'});
-    assert.equal(res.send.getCall(0).args[1], '<html></html>');
-    assert.equal(res.send.getCall(0).args[0], 301);
-  });
-
-  it('should return a prerendered response if user is a bot by checking for _escaped_fragment_', function(){
-    var req = { method: 'GET', url: '/path?_escaped_fragment_=', headers: { 'user-agent': user } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    sinon.stub(prerender, 'getPrerenderedPageResponse').callsArgWith(1, {statusCode: 200, body: '<html></html>'});
-
-    prerender(req, res, next);
-
-    prerender.getPrerenderedPageResponse.restore();
-
-    assert.equal(next.callCount, 0);
-    assert.equal(res.send.callCount, 1);
-    assert.equal(res.send.getCall(0).args[1], '<html></html>');
-  });
-
-  it('should call next() if the url is a bad url with _escaped_fragment_', function(){
-    var req = { method: 'GET', url: '/path?query=params?_escaped_fragment_=', headers: { 'user-agent': user } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender(req, res, next);
-    
-    assert.equal(next.callCount, 1);
-    assert.equal(res.send.callCount, 0);
-  });
-
-  it('should call next() if the request is not a GET', function(){
-    var req = { method: 'POST', url: '/path', headers: { 'user-agent': user } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender(req, res, next);
-    
-    assert.equal(next.callCount, 1);
-    assert.equal(res.send.callCount, 0);
-  });
-
-  it('should call next() if user is not a bot by checking agent string', function(){
-    var req = { method: 'GET', url: '/', headers: { 'user-agent': user } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender(req, res, next);
-    
-    assert.equal(next.callCount, 1);
-    assert.equal(res.send.callCount, 0);
-  });
-
-  it('should call next() if user is a bot, but the bot is requesting a resource file', function(){
-    var req = { method: 'GET', url: '/main.js?anyQueryParam=true', headers: { 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender(req, res, next);
-    
-    assert.equal(next.callCount, 1);
-    assert.equal(res.send.callCount, 0);
-  });
-
-  it('should call next() if the url is not part of the regex specific whitelist', function(){
-    var req = { method: 'GET', url: '/saved/search/blah?_escaped_fragment_=', headers: { 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender.whitelisted(['^/search', '/help'])(req, res, next);
-    
-    delete prerender.whitelist;
-    assert.equal(next.callCount, 1);
-    assert.equal(res.send.callCount, 0);
-  });
-
-  it('should return a prerendered response if the url is part of the regex specific whitelist', function(){
-    var req = { method: 'GET', url: '/search/things?query=blah&_escaped_fragment_=', headers: { 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    sinon.stub(prerender, 'getPrerenderedPageResponse').callsArgWith(1, {statusCode: 200, body: '<html></html>'});
-
-    prerender.whitelisted(['^/search.*query', '/help'])(req, res, next);
-
-    prerender.getPrerenderedPageResponse.restore();
-
-    delete prerender.whitelist;
-    assert.equal(next.callCount, 0);
-    assert.equal(res.send.callCount, 1);
-    assert.equal(res.send.getCall(0).args[1], '<html></html>');
-  });
-
-  it('should call next() if the url is part of the regex specific blacklist', function(){
-    var req = { method: 'GET', url: '/search/things?query=blah', headers: { 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender.blacklisted(['^/search', '/help'])(req, res, next);
-    
-    delete prerender.blacklist;
-    assert.equal(next.callCount, 1);
-    assert.equal(res.send.callCount, 0);
-  });
-
-  it('should return a prerendered response if the url is not part of the regex specific blacklist', function(){
-    var req = { method: 'GET', url: '/profile/search/blah', headers: { 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    sinon.stub(prerender, 'getPrerenderedPageResponse').callsArgWith(1, {statusCode: 200, body: '<html></html>'});
-
-    prerender.blacklisted(['^/search', '/help'])(req, res, next);
-
-    prerender.getPrerenderedPageResponse.restore();
-
-    delete prerender.blacklist;
-    assert.equal(next.callCount, 0);
-    assert.equal(res.send.callCount, 1);
-    assert.equal(res.send.getCall(0).args[1], '<html></html>');
-  });
-
-  it('should call next() if the referer is part of the regex specific blacklist', function(){
-    var req = { method: 'GET', url: '/api/results', headers: { referer: '/search', 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender.blacklisted(['^/search', '/help'])(req, res, next);
-    
-    delete prerender.blacklist;
-    assert.equal(next.callCount, 1);
-    assert.equal(res.send.callCount, 0);
-  });
-
-  it('should return a prerendered response if the referer is not part of the regex specific blacklist', function(){
-    var req = { method: 'GET', url: '/api/results', headers: { referer: '/profile/search', 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    sinon.stub(prerender, 'getPrerenderedPageResponse').callsArgWith(1, {statusCode: 200, body: '<html></html>'});
-
-    prerender.blacklisted(['^/search', '/help'])(req, res, next);
-
-    prerender.getPrerenderedPageResponse.restore();
-
-    delete prerender.blacklist;
-    assert.equal(next.callCount, 0);
-    assert.equal(res.send.callCount, 1);
-    assert.equal(res.send.getCall(0).args[1], '<html></html>');
-  });
-
-  it('should return a prerendered response if a string is returned from beforeRender', function(){
-    var req = { method: 'GET', url: '/', headers: { 'user-agent': bot } },
-      res = { send: sinon.stub(), set: sinon.stub() },
-      next = sinon.stub();
-
-    prerender.set('beforeRender', function(req, done) {
-      done(null, '<html>cached</html>');
+      sinon.stub(prerender, 'buildApiUrl').returns('http://google.com');
     });
 
-    prerender(req, res, next);
+    afterEach(function () {
+      prerender.buildApiUrl.restore();
+    });
 
-    assert.equal(next.callCount, 0);
-    assert.equal(res.send.callCount, 1);
-    assert.equal(res.send.getCall(0).args[1], '<html>cached</html>');
+    it('should return a prerendered response with the returned status code and headers', function(){
+      var req = { method: 'GET', url: '/', headers: { 'user-agent': bot } };
+
+      sinon.stub(request, 'get').returns(mockRequest(301, '<html></html>', { 'Location': 'http://google.com'}));
+
+      prerender(req, res, next);
+
+      request.get.restore();
+
+      assert.equal(next.callCount, 0);
+      assert.equal(res.send.callCount, 1);
+      assert.deepEqual(res.set.getCall(0).args[0], { 'Location': 'http://google.com'});
+      assert.equal(res.write.getCall(0).args[0], '<html></html>');
+      assert.equal(res.send.getCall(0).args[0], 301);
+    });
+
+    it('should return a prerendered response if user is a bot by checking for _escaped_fragment_', function(){
+      var req = { method: 'GET', url: '/path?_escaped_fragment_=', headers: { 'user-agent': user } };
+
+      sinon.stub(request, 'get').returns(mockRequest(200, '<html></html>'));
+
+      prerender(req, res, next);
+
+      request.get.restore();
+
+      assert.equal(next.callCount, 0);
+      assert.equal(res.send.callCount, 1);
+      assert.equal(res.write.getCall(0).args[0], '<html></html>');
+      assert.equal(res.send.getCall(0).args[0], 200);
+    });
+
+    it('should call next() if the url is a bad url with _escaped_fragment_', function(){
+      var req = { method: 'GET', url: '/path?query=params?_escaped_fragment_=', headers: { 'user-agent': user } };
+
+      prerender(req, res, next);
+
+      assert.equal(next.callCount, 1);
+      assert.equal(res.send.callCount, 0);
+    });
+
+    it('should call next() if the request is not a GET', function(){
+      var req = { method: 'POST', url: '/path', headers: { 'user-agent': user } };
+
+      prerender(req, res, next);
+
+      assert.equal(next.callCount, 1);
+      assert.equal(res.send.callCount, 0);
+    });
+
+    it('should call next() if user is not a bot by checking agent string', function(){
+      var req = { method: 'GET', url: '/', headers: { 'user-agent': user } };
+
+      prerender(req, res, next);
+
+      assert.equal(next.callCount, 1);
+      assert.equal(res.send.callCount, 0);
+    });
+
+    it('should call next() if user is a bot, but the bot is requesting a resource file', function(){
+      var req = { method: 'GET', url: '/main.js?anyQueryParam=true', headers: { 'user-agent': bot } };
+
+      prerender(req, res, next);
+
+      assert.equal(next.callCount, 1);
+      assert.equal(res.send.callCount, 0);
+    });
+
+    it('should call next() if the url is not part of the regex specific whitelist', function(){
+      var req = { method: 'GET', url: '/saved/search/blah?_escaped_fragment_=', headers: { 'user-agent': bot } };
+
+      prerender.whitelisted(['^/search', '/help'])(req, res, next);
+
+      delete prerender.whitelist;
+      assert.equal(next.callCount, 1);
+      assert.equal(res.send.callCount, 0);
+    });
+
+    it('should return a prerendered response if the url is part of the regex specific whitelist', function(){
+      var req = { method: 'GET', url: '/search/things?query=blah&_escaped_fragment_=', headers: { 'user-agent': bot } };
+
+      sinon.stub(request, 'get').returns(mockRequest(200, '<html></html>'));
+
+      prerender.whitelisted(['^/search.*query', '/help'])(req, res, next);
+
+      request.get.restore();
+
+      delete prerender.whitelist;
+      assert.equal(next.callCount, 0);
+      assert.equal(res.send.callCount, 1);
+      assert.equal(res.write.getCall(0).args[0], '<html></html>');
+    });
+
+    it('should call next() if the url is part of the regex specific blacklist', function(){
+      var req = { method: 'GET', url: '/search/things?query=blah', headers: { 'user-agent': bot } },
+        res = { send: sinon.stub(), set: sinon.stub() },
+        next = sinon.stub();
+
+      prerender.blacklisted(['^/search', '/help'])(req, res, next);
+
+      delete prerender.blacklist;
+      assert.equal(next.callCount, 1);
+      assert.equal(res.send.callCount, 0);
+    });
+
+    it('should return a prerendered response if the url is not part of the regex specific blacklist', function(){
+      var req = { method: 'GET', url: '/profile/search/blah', headers: { 'user-agent': bot } };
+
+      sinon.stub(request, 'get').returns(mockRequest(200, '<html></html>'));
+
+      prerender.blacklisted(['^/search', '/help'])(req, res, next);
+
+      request.get.restore();
+
+      delete prerender.blacklist;
+      assert.equal(next.callCount, 0);
+      assert.equal(res.send.callCount, 1);
+      assert.equal(res.write.getCall(0).args[0], '<html></html>');
+    });
+
+    it('should call next() if the referer is part of the regex specific blacklist', function(){
+      var req = { method: 'GET', url: '/api/results', headers: { referer: '/search', 'user-agent': bot } };
+
+      prerender.blacklisted(['^/search', '/help'])(req, res, next);
+
+      delete prerender.blacklist;
+      assert.equal(next.callCount, 1);
+      assert.equal(res.send.callCount, 0);
+    });
+
+    it('should return a prerendered response if the referer is not part of the regex specific blacklist', function(){
+      var req = { method: 'GET', url: '/api/results', headers: { referer: '/profile/search', 'user-agent': bot } };
+
+      sinon.stub(request, 'get').returns(mockRequest(200, '<html></html>'));
+
+      prerender.blacklisted(['^/search', '/help'])(req, res, next);
+
+      request.get.restore();
+
+      delete prerender.blacklist;
+      assert.equal(next.callCount, 0);
+      assert.equal(res.send.callCount, 1);
+      assert.equal(res.write.getCall(0).args[0], '<html></html>');
+    });
+
+    it('should return a prerendered response if a string is returned from beforeRender', function(){
+      var req = { method: 'GET', url: '/', headers: { 'user-agent': bot } };
+
+      prerender.set('beforeRender', function(req, done) {
+        done(null, '<html>cached</html>');
+      });
+
+      prerender(req, res, next);
+
+      assert.equal(next.callCount, 0);
+      assert.equal(res.send.callCount, 1);
+      assert.equal(res.send.getCall(0).args[1], '<html>cached</html>');
+    });
   });
 
   describe('#whitelisted', function(){


### PR DESCRIPTION
This is meant to be used with the gzip feature for which I made a pull request in the prerender project.

With the entire chain being in gzip, I see a response time of about 150 ms with gzip content in a nodejs database. This is compared to about 800 ms that I saw without any gzip. So big gains here.

Both the requesting server using prerender-node and the prerender server are running in different heroku apps using 1 dyno.
