### PR TITLE
Add support for Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ prerender.crawlerUserAgents = [
   'rogerbot',
   'linkedinbot',
   'embedly',
-  'bufferbot',
   'quora link preview',
   'showyoubot'
 ];
@@ -99,6 +98,7 @@ prerender.blacklisted = function(blacklist) {
 
 prerender.shouldShowPrerenderedPage = function(req) {  
   var userAgent = req.headers['user-agent']
+    , bufferAgent = req.headers['x-bufferbot']
     , isRequestingPrerenderedPage = false;
 
   if(!userAgent) return false;
@@ -109,6 +109,9 @@ prerender.shouldShowPrerenderedPage = function(req) {
 
   //if it is a bot...show prerendered page
   if(prerender.crawlerUserAgents.some(function(crawlerUserAgent){ return userAgent.toLowerCase().indexOf(crawlerUserAgent.toLowerCase()) !== -1;})) isRequestingPrerenderedPage = true;
+
+  //if it is BufferBot...show prerendered page
+  if(bufferAgent) isRequestingPrerenderedPage = true;
 
   //if it is a bot and is requesting a resource...dont prerender
   if(prerender.extensionsToIgnore.some(function(extension){return req.url.indexOf(extension) !== -1;})) return false;


### PR DESCRIPTION
Follow up to https://github.com/prerender/prerender-node/pull/15, which didn't actually add support for Buffer since they've stopped using the BufferBot user agent and switched to a custom header.

From [Buffer](https://bufferapp.com/):

> So as far as i'm aware we fake our agent to be a real browser as some sites return 'incompatible browser' otherwise. We do have a HTTP header which you can look for which is... "X-BufferBot: Being Awesome! P.S. We're hiring! jobs.bufferapp.com"
