### PR TITLE
Adding retry functionality.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,18 +12,26 @@ var prerender = module.exports = function(req, res, next) {
       return res.send(200, cachedRender);
     }
 
-    prerender.getPrerenderedPageResponse(req, function(prerenderedResponse){
-
-      if(prerenderedResponse) {
-        prerender.afterRenderFn(req, prerenderedResponse);
-        res.set(prerenderedResponse.headers);
-        return res.send(prerenderedResponse.statusCode, prerenderedResponse.body);
-      }
-
-      next();
+    prerender.getPrerenderedPageResponse(req, function(prerenderedResponse) {
+        prerender.handleResponse(prerenderedResponse, req, res, next, 1);
     });
   });
 };
+
+prerender.handleResponse = function(prerenderedResponse, req, res, next, retries) {
+  var shouldRetry = this.retryFn(prerenderedResponse);
+  if (shouldRetry && this.retryLimit && retries < this.retryLimit) {
+    prerender.getPrerenderedPageResponse(req, function(prerenderedResponse) {
+        prerender.handleResponse(prerenderedResponse, req, res, next, ++retries);
+    });
+  } else if (prerenderedResponse) {
+    prerender.afterRenderFn(req, prerenderedResponse);
+    res.set(prerenderedResponse.headers);
+    return res.send(prerenderedResponse.statusCode, prerenderedResponse.body);
+  } else {
+    next();
+  }
+}
 
 // googlebot, yahoo, and bingbot are not in this list because
 // we support _escaped_fragment_ and want to ensure people aren't
@@ -223,6 +231,11 @@ prerender.beforeRenderFn = function(req, done) {
   return this.beforeRender(req, done);
 };
 
+prerender.retryFn = function(prerender_res) {
+  if (!this.retry) return false;
+
+  return this.retry(prerender_res);
+};
 
 prerender.afterRenderFn = function(req, prerender_res) {
   if (!this.afterRender) return;


### PR DESCRIPTION
When using this middleware with a custom server, we found the prerender server to be crashing non-deterministically.  After lots of debugging, we decided that perhaps the best solution was one in which the middleware retried intelligently.  To this end, we've added two (optional) parameters.

```
.set('retry', function(prerender_res) {
    return false;
});
```

Retry is a function that takes the prerender response, and returns true if (and only if) the middle-ware ought to retry the request.

```
.set('retryLimit', 0);
```

retryLimit is a configuration variable which controls the number of total tries a request is allowed.  Anything less than one is considered equivalent to one.

We wanted to commit back to the community, and make this middleware more usable by all involved.  Please, let us know what we can do to get this merged into repo.
