### PR TITLE
Adding retry functionality.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var prerender = module.exports = function(req, res, next) {
 };
 
 prerender.handleResponse = function(prerenderedResponse, req, res, next, retries) {
-  var shouldRetry = this.retryFn(prerenderedResponse);
+  var shouldRetry = this.retryFn(req, prerenderedResponse);
   if (shouldRetry && this.retryLimit && retries < this.retryLimit) {
     prerender.getPrerenderedPageResponse(req, function(prerenderedResponse) {
         prerender.handleResponse(prerenderedResponse, req, res, next, ++retries);
@@ -231,10 +231,10 @@ prerender.beforeRenderFn = function(req, done) {
   return this.beforeRender(req, done);
 };
 
-prerender.retryFn = function(prerender_res) {
+prerender.retryFn = function(req, prerender_res) {
   if (!this.retry) return false;
 
-  return this.retry(prerender_res);
+  return this.retry(req, prerender_res);
 };
 
 prerender.afterRenderFn = function(req, prerender_res) {


### PR DESCRIPTION
When using this middleware with a custom server, we found the prerender server to be crashing non-deterministically.  After lots of debugging, we decided that perhaps the best solution was one in which the middleware retried intelligently.  To this end, we've added two (optional) parameters.

```
.set('retry', function(prerender_res) {
    return false;
});
```

Retry is a function that takes the prerender response, and returns true if (and only if) the middle-ware ought to retry the request.

```
.set('retryLimit', 0);
```

retryLimit is a configuration variable which controls the number of total tries a request is allowed.  Anything less than one is considered equivalent to one.

We wanted to commit back to the community, and make this middleware more usable by all involved.  Please, let us know what we can do to get this merged into repo.
