### PR TITLE
Adding a setter for "host" to allow forcing the host value in buildApiUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ prerender.buildApiUrl = function(req) {
   if (this.protocol) {
     protocol = this.protocol;
   }
-  var fullUrl = protocol + "://" + req.get('host') + req.url;
+  var fullUrl = protocol + "://" + (this.host || req.get('host')) + req.url;
   return prerenderUrl + forwardSlash + fullUrl;
 };
 


### PR DESCRIPTION
@thoop Per our email discussion, I've added a field to sidestep the host-clobbering issue (in much the same way as we do with protocol) and force the value. Submitted for your consideration.
