### PR TITLE
Add updatePrerenderPage to send POST requests to the prerender server

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,9 +149,9 @@ prerender.addHeaders = function(req, options) {
   }
 };
 
-prerender.updatePrerenderPage = function(req, path, callback) {
+prerender.updatePrerenderPage = function(req, path, host, callback) {
   var options = {
-    uri: url.parse(prerender.buildApiUrl(req, path)),
+    uri: url.parse(prerender.buildApiUrl(req, path, host)),
     followRedirect: false
   };
 
@@ -211,7 +211,7 @@ prerender.plainResponse = function(response, callback) {
 };
 
 
-prerender.buildApiUrl = function(req, path) {
+prerender.buildApiUrl = function(req, path, host) {
   var prerenderUrl = prerender.getPrerenderServiceUrl();
   var forwardSlash = prerenderUrl.indexOf('/', prerenderUrl.length - 1) !== -1 ? '' : '/';
 
@@ -226,7 +226,7 @@ prerender.buildApiUrl = function(req, path) {
   if (this.protocol) {
     protocol = this.protocol;
   }
-  var fullUrl = protocol + "://" + (this.host || req.get('host')) + (path || req.url);
+  var fullUrl = protocol + "://" + (host || req.get('host')) + (path || req.url);
   return prerenderUrl + forwardSlash + fullUrl;
 };
 

--- a/index.js
+++ b/index.js
@@ -139,12 +139,7 @@ prerender.shouldShowPrerenderedPage = function(req) {
   return isRequestingPrerenderedPage;
 };
 
-
-prerender.getPrerenderedPageResponse = function(req, callback) {
-  var options = {
-    uri: url.parse(prerender.buildApiUrl(req)),
-    followRedirect: false
-  };
+prerender.addHeaders = function(req, options) {
   if(this.prerenderToken || process.env.PRERENDER_TOKEN) {
     options.headers = {
       'X-Prerender-Token': this.prerenderToken || process.env.PRERENDER_TOKEN,
@@ -152,8 +147,30 @@ prerender.getPrerenderedPageResponse = function(req, callback) {
       'Accept-Encoding': 'gzip'
     };
   }
+};
 
-	request.get(options).on('response', function(response) {
+prerender.updatePrerenderPage = function(req, path, callback) {
+  var options = {
+    uri: url.parse(prerender.buildApiUrl(req, path)),
+    followRedirect: false
+  };
+
+  this.addHeaders(req, options);
+
+  var r = request.post(options);
+  if (callback) {
+    r.on('response', callback).on('error', callback);
+  }
+};
+
+prerender.getPrerenderedPageResponse = function(req, callback) {
+  var options = {
+    uri: url.parse(prerender.buildApiUrl(req)),
+    followRedirect: false
+  };
+  this.addHeaders(req, options);
+
+  request.get(options).on('response', function(response) {
     if(response.headers['content-encoding'] && response.headers['content-encoding'] === 'gzip') {
       prerender.gunzipResponse(response, callback);
     } else {
@@ -194,7 +211,7 @@ prerender.plainResponse = function(response, callback) {
 };
 
 
-prerender.buildApiUrl = function(req) {
+prerender.buildApiUrl = function(req, path) {
   var prerenderUrl = prerender.getPrerenderServiceUrl();
   var forwardSlash = prerenderUrl.indexOf('/', prerenderUrl.length - 1) !== -1 ? '' : '/';
 
@@ -209,7 +226,7 @@ prerender.buildApiUrl = function(req) {
   if (this.protocol) {
     protocol = this.protocol;
   }
-  var fullUrl = protocol + "://" + (this.host || req.get('host')) + req.url;
+  var fullUrl = protocol + "://" + (this.host || req.get('host')) + (path || req.url);
   return prerenderUrl + forwardSlash + fullUrl;
 };
 

--- a/index.js
+++ b/index.js
@@ -150,6 +150,7 @@ prerender.addHeaders = function(req, options) {
 };
 
 prerender.updatePrerenderPage = function(req, path, host, callback) {
+  console.log('Update updatePrerenderPage, path=' + path + ', host=' + host);
   var options = {
     uri: url.parse(prerender.buildApiUrl(req, path, host)),
     followRedirect: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "1.1.0",
+  "version": "update-1.2",
   "description": "express middleware for serving prerendered javascript-rendered pages for SEO",
   "author": "Todd Hooper",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "update-1.2",
+  "version": "1.1.90",
   "description": "express middleware for serving prerendered javascript-rendered pages for SEO",
   "author": "Todd Hooper",
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -236,6 +236,20 @@ describe('Prerender', function(){
       assert.equal(res.send.callCount, 1);
       assert.equal(res.send.getCall(0).args[0], '<html>cached</html>');
     });
+
+    describe('updatePrerenderPage', function () {
+      it('should a post url with the path', function(){
+        var req = { method: 'GET', url: '/search/things?query=blah&_escaped_fragment_=', headers: { 'user-agent': bot } };
+
+        sandbox.stub(request, 'post').returns(mockRequest(200, '<html></html>'));
+
+        prerender.updatePrerenderPage(req, '/search/things?query=blah');
+
+        assert.equal(request.post.getCall(0).args[0].uri.href, 'http://google.com/');
+        assert.equal(request.post.getCall(0).args[0].headers['X-Prerender-Token'], 'MY_TOKEN');
+        assert.equal(request.post.getCall(0).args[0].headers['Accept-Encoding'], 'gzip');
+      });
+    })
   });
 
   describe('#whitelisted', function(){


### PR DESCRIPTION
I'm using the prerender-node from my node web server which is also updating the database. Therefore it knows when an object is updated and therefore the currently prerendered cached page is out of date. So instead of doing a POST request to the prerender server myself I thought it would be more convenient to add a function in prerender-node since it already has all the code to make a request to the prerender server.

Usage:
```javascript
var prerenderNode = require('prerender-node');
prerenderNode.updatePrerenderPage(req, '/path-to-page/');
```