### PR TITLE
Feature/always pass headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ prerender.getPrerenderedPageResponse = function(req, callback) {
     options.headers['X-Prerender-Token'] = this.prerenderToken || process.env.PRERENDER_TOKEN;
   }
 
-	request.get(options).on('response', function(response) {
+  request.get(options).on('response', function(response) {
     if(response.headers['content-encoding'] && response.headers['content-encoding'] === 'gzip') {
       prerender.gunzipResponse(response, callback);
     } else {


### PR DESCRIPTION
This fixes the issue of User-Agent and Accept-Encoding headers being passed to prerender server **only** when prerender token was used.
It should provide some speedup (because of gzip) if the result page is big enough.
