### PR TITLE
Don't rely on global mocha for npm test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "sinon": "~1.7.3"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "./node_modules/.bin/mocha"
   },
   "dependencies": {
     "request": "~2.40.0"


### PR DESCRIPTION
The previous syntax requires you to have `npm install -g`'d `mocha`. This allows it to work with just a local `npm install`.