### PR TITLE
Fixes a problem with URLs containing double hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ prerender.buildApiUrl = function(req) {
   if (this.protocol) {
     protocol = this.protocol;
   }
-  var fullUrl = protocol + "://" + (this.host || req.headers['host']) + req.url;
+  var fullUrl = protocol + "://" + (this.host || req.headers['host']) + encodeURIComponent(req.url);
   return prerenderUrl + forwardSlash + fullUrl;
 };
 


### PR DESCRIPTION
URLs like "http://aber-owl.net/ontology/AURA#!http://www.projecthalo.com/aura#Einsteinium" that contain the #! plus an additional hash won't be requested properly, because the value of _escaped_fragment_ gets decoded before but is not properly encoded again. For example, a request to http://aber-owl.net/ontology/AURA?_escaped_fragment_=http%3A%2F%2Fwww.projecthalo.com%2Faura%23Acetaldehyde) decodes the second part as well, and the request is then chopped of at %23 (#) to http://aber-owl.net/ontology/AURA#!http://www.projecthalo.com/aura instead of http://aber-owl.net/ontology/AURA#!http://www.projecthalo.com/aura#Acetaldehyde