### PR TITLE
Make it work with node v6.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,8 +128,7 @@ prerender.shouldShowPrerenderedPage = function(req) {
   if(req.method != 'GET' && req.method != 'HEAD') return false;
 
   //if it contains _escaped_fragment_, show prerendered page
-  var parsedQuery = url.parse(req.url, true).query;
-  if(parsedQuery && parsedQuery.hasOwnProperty('_escaped_fragment_')) isRequestingPrerenderedPage = true;
+  if(Object.prototype.hasOwnProperty.call(parsedQuery, '_escaped_fragment_')) isRequestingPrerenderedPage = true;
 
   //if it is a bot...show prerendered page
   if(prerender.crawlerUserAgents.some(function(crawlerUserAgent){ return userAgent.toLowerCase().indexOf(crawlerUserAgent.toLowerCase()) !== -1;})) isRequestingPrerenderedPage = true;

--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ prerender.shouldShowPrerenderedPage = function(req) {
   if(req.method != 'GET' && req.method != 'HEAD') return false;
 
   //if it contains _escaped_fragment_, show prerendered page
+  var parsedQuery = url.parse(req.url, true).query;
   if(Object.prototype.hasOwnProperty.call(parsedQuery, '_escaped_fragment_')) isRequestingPrerenderedPage = true;
 
   //if it is a bot...show prerendered page


### PR DESCRIPTION
I recently upgraded node to v6, but this module is broken after the upgrade. The error message is:

```
TypeError: parsedQuery.hasOwnProperty is not a function
```

To reproduce the problem, try evaluate the following with Node v6:
```
require('url').parse('', true).query.hasOwnProperty('test')
```

It turns out that when query is an empty string, the query object returned from `url.parse` has no method `hasOwnProperty`. This patch fixes the problem.
