### PR TITLE
Improve compatibility with Node.js v6.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ prerender.shouldShowPrerenderedPage = function(req) {
 
   //if it contains _escaped_fragment_, show prerendered page
   var parsedQuery = url.parse(req.url, true).query;
-  if(parsedQuery && parsedQuery.hasOwnProperty('_escaped_fragment_')) isRequestingPrerenderedPage = true;
+  if(parsedQuery && parsedQuery['_escaped_fragment_'] !== undefined) isRequestingPrerenderedPage = true;
 
   //if it is a bot...show prerendered page
   if(prerender.crawlerUserAgents.some(function(crawlerUserAgent){ return userAgent.toLowerCase().indexOf(crawlerUserAgent.toLowerCase()) !== -1;})) isRequestingPrerenderedPage = true;


### PR DESCRIPTION
`querystring` in node v6 now returns an "empty" object instead of `{}`, causing an error: “TypeError: parsedQuery.hasOwnProperty is not a function”. Instead calling `hasOwnProperty` on `parsedQuery`, just check `parsedQuery['_escaped_fragment_']` instead, as suggested by @thoop