### PR TITLE
Add SkypeUriPreview to crawlerUserAgents

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ prerender.crawlerUserAgents = [
   'WhatsApp',
   'flipboard',
   'tumblr',
-  'bitlybot'
+  'bitlybot',
+  'SkypeUriPreview'
 ];
 
 


### PR DESCRIPTION
Add SkypeUriPreview to crawlerUserAgents so that Skype could show beautiful previews.
![prerender_skype_preview](https://cloud.githubusercontent.com/assets/7405383/17971380/4cd84cf8-6ae3-11e6-891f-1fa37dee01fa.PNG)
