### PR TITLE
Add additional crawler user agents (nuzzel, discord)

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ prerender.crawlerUserAgents = [
   'flipboard',
   'tumblr',
   'bitlybot',
-  'SkypeUriPreview'
+  'SkypeUriPreview',
+  'nuzzel',
+  'discord'
 ];
 
 

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ prerender.crawlerUserAgents = [
   'bitlybot',
   'SkypeUriPreview',
   'nuzzel',
-  'discord'
+  'Discordbot'
 ];
 
 


### PR DESCRIPTION
Nuzzel is a news aggregation service that determines trends based on what people are tweeting.  If a site is tweeted then nuzzel will attempt to scrape that link- without the crawler user agent it will get non-prerendered html. See http://nuzzel.com/

Discord is a chat bot for gamers. Like Slack, it attempts to expand links that are pasted.  Without detecting the user agent properly it will just show the non-prerendered markup when it expands links. https://discordapp.com/