### PR TITLE
Use the x-forwarded-host header for ApiURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ prerender.buildApiUrl = function(req) {
   if (this.protocol) {
     protocol = this.protocol;
   }
-  var fullUrl = protocol + "://" + (this.host || req.headers['host']) + req.url;
+  var fullUrl = protocol + "://" + (this.host || req.headers['x-forwarded-host'] || req.headers['host']) + req.url;
   return prerenderUrl + forwardSlash + fullUrl;
 };
 


### PR DESCRIPTION
When the request includes the X-Forwarded-Host header that value will be used for creating an API Url. This means it will be possible to use prerender-node in a situation where it sits behind one or more proxies.
Fixes #121 