### PR TITLE
Check extensionsToIgnore in case insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ prerender.shouldShowPrerenderedPage = function(req) {
   if(bufferAgent) isRequestingPrerenderedPage = true;
 
   //if it is a bot and is requesting a resource...dont prerender
-  if(prerender.extensionsToIgnore.some(function(extension){return req.url.indexOf(extension) !== -1;})) return false;
+  if(prerender.extensionsToIgnore.some(function(extension){return req.url.toLowerCase().indexOf(extension) !== -1;})) return false;
 
   //if it is a bot and not requesting a resource and is not whitelisted...dont prerender
   if(Array.isArray(this.whitelist) && this.whitelist.every(function(whitelisted){return (new RegExp(whitelisted)).test(req.url) === false;})) return false;


### PR DESCRIPTION
I have many images uploaded by the users with their extensions in upper case (".JPG").
I have just added a ```.toLowerCase()``` to the extensionsToIgnore checking.