### PR TITLE
Allows manipulation of the prerender request options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.6.1 (2016-12-20)
+New features:
+
+  - Adds an option to be able to pass options to the request sent to the prerender.
+
+
 ## 2.6.0 (2016-12-13)
 New features:
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Option to forward headers from request to prerender.
 app.use(require('prerender-node').set('forwardHeaders', true));
 ```
 
+### prerenderServerRequestOptions 
+
+Option to add options to the request sent to the prerender server. 
+```js
+app.use(require('prerender-node').set('prerenderServerRequestOptions', {}));
+```
+
+
+
 ## Caching
 
 This express middleware is ready to be used with [redis](http://redis.io/) or [memcached](http://memcached.org/) to return prerendered pages in milliseconds.

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ prerender.crawlerUserAgents = [
   'SkypeUriPreview',
   'nuzzel',
   'Discordbot',
-	'Google Page Speed'
+  'Google Page Speed'
 ];
 
 
@@ -165,12 +165,15 @@ prerender.shouldShowPrerenderedPage = function(req) {
 };
 
 
+prerender.prerenderServerRequestOptions = {};
+
 prerender.getPrerenderedPageResponse = function(req, callback) {
   var options = {
     uri: url.parse(prerender.buildApiUrl(req)),
     followRedirect: false,
     headers: {}
   };
+  for (var attrname in this.prerenderServerRequestOptions) { options[attrname] = this.prerenderServerRequestOptions[attrname]; }
   if (this.forwardHeaders === true) {
     Object.keys(req.headers).forEach(function(h) {
       // Forwarding the host header can cause issues with server platforms that require it to match the URL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "express middleware for serving prerendered javascript-rendered pages for SEO",
   "author": "Todd Hooper",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "express middleware for serving prerendered javascript-rendered pages for SEO",
   "author": "Todd Hooper",
   "license": "MIT",


### PR DESCRIPTION
This commit allows to set options that will be added to the request sent to the prerender.io server.
You may need this feature for diverse reasons, for example to hit an haproxy load balancer

On the code you can do then something like:
prerender.set('prerenderServerRequestOptions', {headers:{'X-Marathon-App-Id': 'internal-prerender'}});