### PR TITLE
'yahoo' to 'Yahoo! Slurp' since yahoo is also used in webview browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var prerender = module.exports = function(req, res, next) {
 
 prerender.crawlerUserAgents = [
   'googlebot',
-  'yahoo',
+  'Yahoo! Slurp',
   'bingbot',
   'baiduspider',
   'facebookexternalhit',


### PR DESCRIPTION
Hi!
'yahoo' is a pretty generic term that is used in the user agent of many apps internal browsers.

The example below is the UA of Yahoo Japan iOS email app's web browser.
```
Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B176 YJApp-IOS jp.co.yahoo.ymail/5.6.3
```

According to [Yahoo documentation](https://help.yahoo.com/kb/learn-slurp-sln22600.html) the proper identifier for Yahoo search engine should be 'Yahoo! Slurp'.