### PR TITLE
feat: support custom user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Option to forward headers from request to prerender.
 app.use(require('prerender-node').set('forwardHeaders', true));
 ```
 
+### customUserAgent
+
+Option to override User-Agent header sent to the prerender server.
+```js
+app.use(require('prerender-node').set('customUserAgent', 'iPhone'));
+```
+
 ### prerenderServerRequestOptions
 
 Option to add options to the request sent to the prerender server.

--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ prerender.getPrerenderedPageResponse = function(req, callback) {
       options.headers[h] = req.headers[h];
     });
   }
-  options.headers['User-Agent'] = req.headers['user-agent'];
+  options.headers['User-Agent'] = this.customUserAgent || req.headers['user-agent'];
   options.headers['Accept-Encoding'] = 'gzip';
   if(this.prerenderToken || process.env.PRERENDER_TOKEN) {
     options.headers['X-Prerender-Token'] = this.prerenderToken || process.env.PRERENDER_TOKEN;

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -497,6 +497,50 @@ describe ('Prerender', function(){
     });
   });
 
+  describe('#getPrerenderedPageResponse', function() {
+    var sandbox, req, callback;
+
+    beforeEach(function () {
+      var mockRequest = {
+        get: function() {
+          return this;
+        },
+        on: function() {
+          return this;
+        }
+      };
+      
+      sandbox = sinon.sandbox.create();
+      
+      callback = sandbox.stub();
+      req = { 
+        connection: {}, 
+        headers: {
+          'user-agent': 'Mozilla/5.0 (compatible; redditbot/1.0; +http://www.reddit.com/feedback)'
+        },
+      };
+      
+      sandbox.stub(request, 'get').returns(mockRequest);
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+
+    it('makes request with custom user agent when custom user agent is set', function() {
+      prerender.customUserAgent = 'iPhone prerender';
+      prerender.getPrerenderedPageResponse(req, callback);
+      assert.equal(request.get.getCall(0).args[0].headers['User-Agent'], 'iPhone prerender');
+      delete prerender.customUserAgent;
+    });
+    
+    it('makes request with request user agent when custom user agent is not set', function() {
+      prerender.getPrerenderedPageResponse(req, callback);
+      assert.equal(request.get.getCall(0).args[0].headers['User-Agent'], req.headers['user-agent']);
+    });
+  });
+  
   describe('#shouldShowPrerenderedPage', function() {
     it('returns true if bot is redditbot', function() {
       var req = {


### PR DESCRIPTION
### customUserAgent

Option to override User-Agent header sent to the prerender server.
```js
app.use(require('prerender-node').set('customUserAgent', 'iPhone'));
```
