### PR TITLE
Add allowedExtensions to bypass extensionsToIgnore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ app.use(require('prerender-node').blacklisted('^/search'));
 app.use(require('prerender-node').blacklisted(['/search', '/users/.*/profile']));
 ```
 
-### extensionsToAllow
+### allowedExtensions
 
-Allows a given file or files that would normally be ignored by prerender based on their extension to pass thru and be prerendered. Compares using regex, so be specific when possible. If extensionsToAllow is applied, these files will be prerendered.
+Allows a given file or files that would normally be ignored by prerender based on their extension to pass thru and be prerendered. Compares using regex, so be specific when possible. If allowedExtensions is applied, these files will be prerendered.
 ```js
-app.use(require('prerender-node').extensionsToAllow('sitemap.xml'));
+app.use(require('prerender-node').allowedExtensions('sitemap.xml'));
 ```
 ```js
-app.use(require('prerender-node').extensionsToAllow(['favicon.ico', '/sitemap/*.xml']));
+app.use(require('prerender-node').allowedExtensions(['favicon.ico', '/sitemap/*.xml']));
 ```
 
 ### beforeRender

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ app.use(require('prerender-node').blacklisted('^/search'));
 app.use(require('prerender-node').blacklisted(['/search', '/users/.*/profile']));
 ```
 
+### extensionsToAllow
+
+Allows a given file or files that would normally be ignored by prerender based on their extension to pass thru and be prerendered. Compares using regex, so be specific when possible. If extensionsToAllow is applied, these files will be prerendered.
+```js
+app.use(require('prerender-node').extensionsToAllow('sitemap.xml'));
+```
+```js
+app.use(require('prerender-node').extensionsToAllow(['favicon.ico', '/sitemap/*.xml']));
+```
+
 ### beforeRender
 
 This method is intended to be used for caching, but could be used to save analytics or anything else you need to do for each crawler request. If you return a string from beforeRender, the middleware will serve that to the crawler (with status `200`) instead of making a request to the prerender service. If you return an object the middleware will look for a `status` and `body` property (defaulting to `200` and `""` respectively) and serve those instead.

--- a/index.js
+++ b/index.js
@@ -129,6 +129,11 @@ prerender.blacklisted = function(blacklist) {
 };
 
 
+prerender.allowedExtensions = function(extensionsToAllow) {
+  prerender.extensionsToAllow = typeof extensionsToAllow === 'string' ? [extensionsToAllow] : extensionsToAllow;
+  return this;
+}
+
 prerender.shouldShowPrerenderedPage = function(req) {
   var userAgent = req.headers['user-agent']
     , bufferAgent = req.headers['x-bufferbot']
@@ -149,7 +154,10 @@ prerender.shouldShowPrerenderedPage = function(req) {
   if(bufferAgent) isRequestingPrerenderedPage = true;
 
   //if it is a bot and is requesting a resource...dont prerender
-  if(prerender.extensionsToIgnore.some(function(extension){return req.url.toLowerCase().indexOf(extension) !== -1;})) return false;
+  if(prerender.extensionsToIgnore.some(function(extension){return req.url.toLowerCase().indexOf(extension) !== -1;})){
+    //if there is a list of allowed files or extensions let them through
+    if(!Array.isArray(this.extensionsToAllow) || !this.extensionsToAllow.some(function(allowed){return (new RegExp(allowed)).test(req.url) === true;})) return false;
+  }
 
   //if it is a bot and not requesting a resource and is not whitelisted...dont prerender
   if(Array.isArray(this.whitelist) && this.whitelist.every(function(whitelisted){return (new RegExp(whitelisted)).test(req.url) === false;})) return false;


### PR DESCRIPTION
Adds an allowedExtensions regex to allow the client to indicate files or extensions which should be prerendered, overriding the internal extensionsToIgnore list