### PR TITLE
refactor: add seznam bot crawler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.1 (2022-01-17)
+Added:
+
+- Add seznam.cz bot to the recognized user agents
+
 ## 3.4.0 (2021-11-09)
 Changed:
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ prerender.crawlerUserAgents = [
   'Bitrix link preview',
   'XING-contenttabreceiver',
   'Chrome-Lighthouse',
-  'TelegramBot'
+  'TelegramBot',
+  'SeznamBot',
 ];
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "express middleware for serving prerendered javascript-rendered pages for SEO",
   "author": "Todd Hooper",
   "license": "MIT",


### PR DESCRIPTION
Please add SeznamBot useragent. Seznam.cz https://www.seznam.cz/ is a search engine in the Czech Republic, serving potentially 10 million people.

Full user agent of seznam bot is `Mozilla/5.0 (compatible; SeznamBot/3.2; +http://napoveda.seznam.cz/en/seznambot-intro/)`

I tested this change on my (Czech) website https://www.nedatluj.cz/ On prerender.io you can see after this change, seznam bot started crawling my site.

<img width="1005" alt="Screen Shot 2022-01-15 at 8 15 28" src="https://user-images.githubusercontent.com/2588479/149613270-9287c87c-fff9-4410-ad87-48e5fc98dcdd.png">

Also here is the log from my server after this change. I am logging the bots with the `console.log` from other branch https://github.com/jirikrepl/prerender-node/commit/4690231fc2937b3332d4a3db2982de2f87bc3dfd#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L32

<img width="1848" alt="Screen Shot 2022-01-15 at 8 18 27" src="https://user-images.githubusercontent.com/2588479/149613299-74ebff2e-b501-4cae-87a8-3165fc40bd93.png">


