### PR TITLE
Version 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.6.0 (2023-03-15)
+Added:
+
+- .webp, .woff2 extensions to the list of extensions that are not prerendered
+- Add AhrefsBot to the recognized user agents
+- Add AhrefsSiteAudit to the recognized user agents
+- Add Iframely to the recognized user agents
+- Add screaming frog to the recognized user agents
+
+## 3.5.0 ()
+Added:
+
+- cancelRender flag in afterRender callback
+
 ## 3.4.2 (2022-03-21)
 Fixed:
 

--- a/index.js
+++ b/index.js
@@ -76,9 +76,10 @@ prerender.crawlerUserAgents = [
   'Chrome-Lighthouse',
   'TelegramBot',
   'SeznamBot',
-  'screaming frog SEO spider'
+  'screaming frog SEO spider',
   'AhrefsBot',
-  'AhrefsSiteAudit'
+  'AhrefsSiteAudit',
+  'Iframely'
 ];
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "express middleware for serving prerendered javascript-rendered pages for SEO",
   "author": "Todd Hooper",
   "license": "MIT",


### PR DESCRIPTION
Updated changelog with 3.5.0 updates (they were missing).

Changelog:

## 3.6.0 (2023-03-15)
Added:

- .webp, .woff2 extensions to the list of extensions that are not prerendered
- Add AhrefsBot to the recognized user agents
- Add AhrefsSiteAudit to the recognized user agents
- Add Iframely to the recognized user agents
- Add screaming frog to the recognized user agents