### PR TITLE
Security: add ignoreXForwardedHost option to block SSRF attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.0 (2023-12-22)
+Added:
+ - Added option `ignoreXForwardedHost` to ignore any `X-Forwarded-Host` headers, which can be used to block SSRF attacks
+
 ## 3.7.0 (2023-05-22)
 Added:
  - Add Google-InspectionTool to the recognized user agents

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Option to ignore `X-Forwarded-Host` header. Can be used to block SSRF attacks.
 **Important:** this header is used to preserve the original host header for servers that sit behind a load balancer or internal reverse proxy. If your server does not need this header then it's probably safe to enable this option. Check your environment before enabling this option and make sure to test it first.
 
 The url that Prerender will get and return the (possibly cached) contents of is created by taking the first available of the following:  
-- The `host` option, as set with `app.use(require('prerender-node').set('host', 'example.com'));`
-- The `X-Forwarded-Host` header, if `ignoreXForwardedHost` is **NOT** set to `true`
-- The Host header
+- The `host` option, as set with `app.use(require('prerender-node').set('host', 'example.com'));`  
+- The `X-Forwarded-Host` header, if `ignoreXForwardedHost` is **NOT** set to `true`  
+- The Host header  
 Finally the originally requested url path is added to the end.
 
 The Prerender.io servers will connect to any url you specify at the end of the prerender service URL. This means that if someone visits `https://mysite.com`, and the request is modified with the path `/some/path` and the header `x-forwarded-host` set to `example.com`, Prerender will connect to `https://example.com/some/path`. (You actually don't need to intercept any request, you can just run the whole request directly, e.g. by using Postman.)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ Option to forward headers from request to prerender.
 app.use(require('prerender-node').set('forwardHeaders', true));
 ```
 
+### ignoreXForwardedHost
+
+Option to ignore `X-Forwarded-Host` header. Can be used to block SSRF attacks.
+
+**Important:** this header is used to preserve the original host header for servers that sit behind a load balancer or internal reverse proxy. If your server does not need this header then it's probably safe to enable this option. Check your environment before enabling this option and make sure to test it first.
+
+The url that Prerender will get and return the (possibly cached) contents of is created by taking the first available of the following:  
+- The `host` option, as set with `app.use(require('prerender-node').set('host', 'example.com'));`
+- The `X-Forwarded-Host` header, if `ignoreXForwardedHost` is **NOT** set to `true`
+- The Host header
+Finally the originally requested url path is added to the end.
+
+The Prerender.io servers will connect to any url you specify at the end of the prerender service URL. This means that if someone visits `https://mysite.com`, and the request is modified with the path `/some/path` and the header `x-forwarded-host` set to `example.com`, Prerender will connect to `https://example.com/some/path`. (You actually don't need to intercept any request, you can just run the whole request directly, e.g. by using Postman.)
+
+If you set `ignoreXForwardedHost` to `true`, the `X-Forwarded-Host` header will be ignored, effectively blocking these SSRF attacks.
+
+```js
+app.use(require('prerender-node').set('ignoreXForwardedHost', true));
+```
+
 ### prerenderServerRequestOptions
 
 Option to add options to the request sent to the prerender server.

--- a/index.js
+++ b/index.js
@@ -271,7 +271,10 @@ prerender.buildApiUrl = function(req) {
   if (this.protocol) {
     protocol = this.protocol;
   }
-  var fullUrl = protocol + "://" + (this.host || req.headers['x-forwarded-host'] || req.headers['host']) + req.url;
+
+  // if set, ignore X-Forwarded-Host header to block SSRF attacks
+  const xforwardedHost = this.ignoreXForwardedHost !== true && req.headers['x-forwarded-host'];
+  const fullUrl = `${protocol}://${this.host || xforwardedHost || req.headers.host}${req.url}`;
   return prerenderUrl + forwardSlash + fullUrl;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prerender-node",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/nico014/prerender-node"
+    "url": "git://github.com/prerender/prerender-node"
   },
   "keywords": [
     "angular",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "prerender-node",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "express middleware for serving prerendered javascript-rendered pages for SEO",
   "author": "Todd Hooper",
   "license": "MIT",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/prerender/prerender-node"
+    "url": "git://github.com/nico014/prerender-node"
   },
   "keywords": [
     "angular",


### PR DESCRIPTION
This option is a workaround to block potential SSRF attacks on Prerender servers until Prerender has found a way to address the vulnerability themselves. (It's been over 3 months at the time of writing.)

If you run this request on a Prerender-enabled server:
```
GET /get HTTP/1.1
User-Agent: TelegramBot
x-forwarded-host: httpbin.org
```

..you will see the response from httpbin.org, which in this case returns details about the request and its origins.

This means that one can have the Prerender server perform requests to outside hosts, even if they have nothing to do with the website that Prerender is enabled for. There is a name for this: Server Side Request Forgery.

This PR adds an option to ignore the `x-forwarded-host` header, which contains the "payload", if any.
BEWARE: the `x-forwarded-host` header might actually be needed in some situations (reverse proxy). I have added notes about this in the README file.